### PR TITLE
Marking shopping list items as purchased

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,10 @@ export function App() {
 							<Home user={user} data={lists} setListPath={setListPath} />
 						}
 					/>
-					<Route path="/list" element={<List data={data} />} />
+					<Route
+						path="/list"
+						element={<List data={data} listPath={listPath} />}
+					/>
 					<Route
 						path="/manage-list"
 						element={<ManageList listPath={listPath} user={user} />}

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -207,10 +207,8 @@ export async function updateItem(listPath, id, checked) {
 				checked: checked,
 			});
 		}
-
-		console.log('item updated');
 	} catch (error) {
-		console.log(error);
+		console.error('There was an error updating the item state: ', error);
 	}
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -188,20 +188,25 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem(listPath, id, checked) {
-	//const listCollectionRef = collection(db, listPath, 'items');
-	const itemRef = doc(collection(db, listPath, 'items'), id);
+	const listCollectionRef = collection(db, listPath, 'items');
+	const itemRef = doc(listCollectionRef, id);
+
 	try {
 		const itemDoc = await getDoc(itemRef);
 		const data = itemDoc.data();
 		const currentTotalPurchases = data.totalPurchases;
-		//console.log(currentTotalPurchases)
 
-		await updateDoc(itemRef, {
-			dateLastPurchased: new Date(),
-			//totalPurchases is undefiend to be debugged
-			totalPurchases: currentTotalPurchases + 1,
-			checked: checked,
-		});
+		if (checked) {
+			await updateDoc(itemRef, {
+				dateLastPurchased: new Date(),
+				totalPurchases: currentTotalPurchases + 1,
+				checked: checked,
+			});
+		} else {
+			await updateDoc(itemRef, {
+				checked: checked,
+			});
+		}
 
 		console.log('item updated');
 	} catch (error) {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -7,7 +7,6 @@ import {
 	onSnapshot,
 	updateDoc,
 	addDoc,
-	FieldValue,
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
@@ -188,19 +187,18 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 }
 
 export async function updateItem(listPath, id) {
-	//console.log(itemName)
 	//const listCollectionRef = collection(db, listPath, 'items');
 	const itemRef = doc(collection(db, listPath, 'items'), id);
-	//const itemtDoc = await getDoc(itemRef);
-	//console.log(parseInt(itemtDoc._document.data.value.mapValue.fields.totalPurchases.integerValue) + 1)
 	try {
+		const itemDoc = await getDoc(itemRef);
+		const data = itemDoc.data();
+		const currentTotalPurchases = data.totalPurchases;
+		//console.log(currentTotalPurchases)
+
 		await updateDoc(itemRef, {
 			dateLastPurchased: new Date(),
 			//totalPurchases is undefiend to be debugged
-			totalPurchases: {
-				...prevFields,
-				integerValue: parseInt(totalPurchases.integerValue) + 1,
-			},
+			totalPurchases: currentTotalPurchases + 1,
 		});
 
 		console.log('item updated');

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -183,10 +183,11 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 		dateNextPurchased: getFutureDate(daysUntilNextPurchase),
 		name: itemName,
 		totalPurchases: 0,
+		checked: false,
 	});
 }
 
-export async function updateItem(listPath, id) {
+export async function updateItem(listPath, id, checked) {
 	//const listCollectionRef = collection(db, listPath, 'items');
 	const itemRef = doc(collection(db, listPath, 'items'), id);
 	try {
@@ -199,6 +200,7 @@ export async function updateItem(listPath, id) {
 			dateLastPurchased: new Date(),
 			//totalPurchases is undefiend to be debugged
 			totalPurchases: currentTotalPurchases + 1,
+			checked: checked,
 		});
 
 		console.log('item updated');

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -7,6 +7,7 @@ import {
 	onSnapshot,
 	updateDoc,
 	addDoc,
+	FieldValue,
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
@@ -186,12 +187,26 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem() {
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item. You'll need to figure out what arguments
-	 * this function must accept!
-	 */
+export async function updateItem(listPath, id) {
+	//console.log(itemName)
+	//const listCollectionRef = collection(db, listPath, 'items');
+	const itemRef = doc(collection(db, listPath, 'items'), id);
+	//const itemtDoc = await getDoc(itemRef);
+	//console.log(parseInt(itemtDoc._document.data.value.mapValue.fields.totalPurchases.integerValue) + 1)
+	try {
+		await updateDoc(itemRef, {
+			dateLastPurchased: new Date(),
+			//totalPurchases is undefiend to be debugged
+			totalPurchases: {
+				...prevFields,
+				integerValue: parseInt(totalPurchases.integerValue) + 1,
+			},
+		});
+
+		console.log('item updated');
+	} catch (error) {
+		console.log(error);
+	}
 }
 
 export async function deleteItem() {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,15 +1,38 @@
 import './ListItem.css';
 import { updateItem } from '../api';
+import { useEffect } from 'react';
 
-export function ListItem({ name, listPath, id }) {
-	//console.log(listPath)
-	const handleOnChange = async () => {
-		await updateItem(listPath, id);
+export function ListItem({ name, listPath, id, isChecked }) {
+	const handleOnChange = async (event) => {
+		//console.log(event);
+		let { value, checked } = event.target;
+		console.log('value before update', value);
+		await updateItem(listPath, id, !checked);
+		if (value) {
+			console.log('value inside if block', value);
+			setTimeout(async () => {
+				await updateItem(listPath, id, !checked);
+				//checked = isChecked;
+				console.log('fjkdsvhjkfdsh', value);
+			}, 5000);
+		}
+		console.log(value);
 	};
+	// useEffect(() => {
+	// 	setTimeout(async () => {
+	// 		await updateItem(listPath, id, !checked);
+	// 	}, 1000);
+	// }, [checked]);
 
 	return (
 		<li className="ListItem">
-			<input type="checkbox" id={id} onChange={handleOnChange} />
+			<input
+				type="checkbox"
+				id={id}
+				value={isChecked}
+				onChange={handleOnChange}
+				checked={isChecked}
+			/>
 			<label htmlFor={`${id}`}>{name}</label>
 		</li>
 	);

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,5 +1,16 @@
 import './ListItem.css';
+import { updateItem } from '../api';
 
-export function ListItem({ name }) {
-	return <li className="ListItem">{name}</li>;
+export function ListItem({ name, listPath, id }) {
+	//console.log(listPath)
+	const handleOnChange = async () => {
+		await updateItem(listPath, id);
+	};
+
+	return (
+		<li className="ListItem">
+			<input type="checkbox" id={id} onChange={handleOnChange} />
+			<label htmlFor={`${id}`}>{name}</label>
+		</li>
+	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,37 +1,33 @@
 import './ListItem.css';
 import { updateItem } from '../api';
 import { useEffect } from 'react';
+import { ONE_DAY_IN_MILLISECONDS } from '../utils/dates';
 
-export function ListItem({ name, listPath, id, isChecked }) {
+export function ListItem({ name, listPath, id, isChecked, datePurchased }) {
 	const handleOnChange = async (event) => {
-		//console.log(event);
-		let { value, checked } = event.target;
-		console.log('value before update', value);
-		await updateItem(listPath, id, !checked);
-		if (value) {
-			console.log('value inside if block', value);
-			setTimeout(async () => {
-				await updateItem(listPath, id, !checked);
-				//checked = isChecked;
-				console.log('fjkdsvhjkfdsh', value);
-			}, 5000);
-		}
-		console.log(value);
+		let { checked } = event.target;
+		if (!checked) return;
+
+		await updateItem(listPath, id, checked);
 	};
-	// useEffect(() => {
-	// 	setTimeout(async () => {
-	// 		await updateItem(listPath, id, !checked);
-	// 	}, 1000);
-	// }, [checked]);
+
+	useEffect(() => {
+		const today = new Date().getTime();
+		const datePurchasedInMillis = datePurchased.toMillis();
+
+		if (isChecked && today - datePurchasedInMillis >= ONE_DAY_IN_MILLISECONDS) {
+			updateItem(listPath, id, !isChecked);
+		}
+	}, []);
 
 	return (
 		<li className="ListItem">
 			<input
 				type="checkbox"
 				id={id}
-				value={isChecked}
 				onChange={handleOnChange}
 				checked={isChecked}
+				disabled={isChecked}
 			/>
 			<label htmlFor={`${id}`}>{name}</label>
 		</li>

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -1,4 +1,4 @@
-const ONE_DAY_IN_MILLISECONDS = 86400000;
+export const ONE_DAY_IN_MILLISECONDS = 86400000;
 
 /**
  * Get a new JavaScript Date that is `offset` days in the future.

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -3,7 +3,6 @@ import './Home.css';
 import CreateShoppingList from '../components/CreateShoppingList';
 
 export function Home({ user, data, setListPath }) {
-	//console.log(user)
 	return (
 		<div className="Home">
 			<p>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ListItem, SearchBar } from '../components';
 
-export function List({ data }) {
+export function List({ data, listPath }) {
 	const [search, setSearch] = useState('');
 	const [displayData, setDisplayData] = useState([]);
 
@@ -19,7 +19,12 @@ export function List({ data }) {
 			/>
 			<ul>
 				{displayData.map((item) => (
-					<ListItem key={item.id} name={item.name} />
+					<ListItem
+						key={item.id}
+						name={item.name}
+						listPath={listPath}
+						id={item.id}
+					/>
 				))}
 			</ul>
 		</>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -25,6 +25,7 @@ export function List({ data, listPath }) {
 						listPath={listPath}
 						id={item.id}
 						isChecked={item.checked}
+						datePurchased={item.dateLastPurchased}
 					/>
 				))}
 			</ul>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -24,6 +24,7 @@ export function List({ data, listPath }) {
 						name={item.name}
 						listPath={listPath}
 						id={item.id}
+						isChecked={item.checked}
 					/>
 				))}
 			</ul>


### PR DESCRIPTION
## Description

User can now check items as purchased on their lists, updating the firestore information on the item and unchecking automatically after 24h of purchase.

## Related Issue

Closes #9 

## Acceptance Criteria

- [x] The `ListItem` component renders a checkbox with a semantic `<label>`.
- [x] Checking off the item in the UI also updates the `dateLastPurchased` and `totalPurchases` properties on the corresponding Firestore document.
- [x] The item is shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day). After 24 hours, the item unchecks itself so the user can buy it again.
- [x] The `updateItem` function in `firebase.js` has been filled out, and sends updates to the firestore database when an item is checked.

## Type of Changes

feature

## Updates

### Before

![image](https://github.com/user-attachments/assets/a6c6e34f-faa9-479e-9dcc-19c95a6c4df7)

### After

![image](https://github.com/user-attachments/assets/2f3073cb-3c2b-44ba-ae2c-2878ab6687c0)

## Testing Steps / QA Criteria

- Do a `git checkout hm-qg-updateItemPurchasedState` and `git pull`.
- Open the homepage by running `npm start`.
- Navigate to `List`, each item should have a checkbox before it.
- Checking one of the checkboxes should update the `checked` and `dateLastPurchased` fields for the item on firestore.
- To confirm the unchecking after 24h works as expected, manually modify the `dateLastPurchased`  to one day prior and one minute forward. Wait until the time condition is met and reload the page: the checkbox should now be unchecked.
