### PR TITLE
conditional datePurchased

### DIFF
--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -13,7 +13,7 @@ export function ListItem({ name, listPath, id, isChecked, datePurchased }) {
 
 	useEffect(() => {
 		const today = new Date().getTime();
-		const datePurchasedInMillis = datePurchased.toMillis();
+		const datePurchasedInMillis = datePurchased?.toMillis();
 
 		if (isChecked && today - datePurchasedInMillis >= ONE_DAY_IN_MILLISECONDS) {
 			updateItem(listPath, id, !isChecked);


### PR DESCRIPTION
## Description

Added a condition to datePurchased in the listItem useEffect to handle cases where it is null.

## Related Issue

NA

## Acceptance Criteria

Fixes production bug

## Type of Changes

`bug fix`

## Updates

### Before

NA

### After

NA

## Testing Steps / QA Criteria

Error when loading a list with an item that has no datePurchased  value should not happen.
