### PR TITLE
Mm qg predict next purchase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.2.0",
 				"firebase": "^10.12.5",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
@@ -3886,6 +3887,16 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.2.0.tgz",
+			"integrity": "sha512-nEN1z/SEOIWO+8JWIgPDNUkrXmXqNomSh5aiZDNdiaUH/JYqyNeXmEOldtMqAfLicSRiFkapcAIlrUUnPzNaog==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
 			}
 		},
 		"node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.2.0",
 		"firebase": "^10.12.5",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -191,30 +191,29 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	});
 }
 
-export async function updateItem(listPath, id, checked) {
+// checked is coming from the handleOnChange function in the ListItem.jsx,so it is not part of the item data.
+export async function updateItem(listPath, checked, itemData) {
+	const { id } = itemData;
 	const listCollectionRef = collection(db, listPath, 'items');
 	const itemRef = doc(listCollectionRef, id);
+	const today = new Date();
+	const currentTotalPurchases = itemData.totalPurchases;
+	const currentDayInterval = itemData.dayInterval;
+	const dateLastPurchasedJavaScriptObject = itemData.dateLastPurchased
+		? itemData.dateLastPurchased.toDate()
+		: itemData.dateCreated.toDate();
+
+	const daysSinceLastPurchase = getDaysBetweenDates(
+		today,
+		dateLastPurchasedJavaScriptObject,
+	);
+	const estimate = calculateEstimate(
+		currentDayInterval,
+		daysSinceLastPurchase,
+		currentTotalPurchases,
+	);
 
 	try {
-		const itemDoc = await getDoc(itemRef);
-		const data = itemDoc.data();
-		const today = new Date();
-		const currentTotalPurchases = data.totalPurchases;
-		const currentDayInterval = data.dayInterval;
-		const dateLastPurchasedJavaScriptObject = data.dateLastPurchased
-			? data.dateLastPurchased.toDate()
-			: data.dateCreated.toDate();
-
-		const daysSinceLastPurchase = getDaysBetweenDates(
-			today,
-			dateLastPurchasedJavaScriptObject,
-		);
-		const estimate = calculateEstimate(
-			currentDayInterval,
-			daysSinceLastPurchase,
-			currentTotalPurchases,
-		);
-
 		if (checked) {
 			await updateDoc(itemRef, {
 				dateLastPurchased: today,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -203,7 +203,7 @@ export async function updateItem(listPath, id, checked) {
 		const currentDayInterval = data.dayInterval;
 		const dateLastPurchasedJavaScriptObject = data.dateLastPurchased
 			? data.dateLastPurchased.toDate()
-			: today;
+			: data.dateCreated.toDate();
 
 		const daysSinceLastPurchase = getDaysBetweenDates(
 			today,
@@ -217,13 +217,11 @@ export async function updateItem(listPath, id, checked) {
 
 		if (checked) {
 			await updateDoc(itemRef, {
-				dateLastPurchased: Timestamp.fromDate(new Date()),
+				dateLastPurchased: today,
 				totalPurchases: currentTotalPurchases + 1,
 				checked: checked,
 				dayInterval: daysSinceLastPurchase,
-				dateNextPurchased: Timestamp.fromMillis(
-					today.setDate(today.getDate() + estimate),
-				),
+				dateNextPurchased: getFutureDate(estimate),
 			});
 		} else {
 			await updateDoc(itemRef, {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,20 +3,41 @@ import { updateItem } from '../api';
 import { useEffect } from 'react';
 import { ONE_DAY_IN_MILLISECONDS } from '../utils/dates';
 
-export function ListItem({ name, listPath, id, isChecked, datePurchased }) {
+export function ListItem({
+	listPath,
+	name,
+	id,
+	isChecked,
+	dateLastPurchased,
+	totalPurchases,
+	dayInterval,
+	dateCreated,
+}) {
 	const handleOnChange = async (event) => {
 		let { checked } = event.target;
 		if (!checked) return;
 
-		await updateItem(listPath, id, checked);
+		await updateItem(listPath, checked, {
+			id,
+			dateLastPurchased,
+			totalPurchases,
+			dayInterval,
+			dateCreated,
+		});
 	};
 
 	useEffect(() => {
 		const today = new Date().getTime();
-		const datePurchasedInMillis = datePurchased?.toMillis();
+		const datePurchasedInMillis = dateLastPurchased?.toMillis();
 
 		if (isChecked && today - datePurchasedInMillis >= ONE_DAY_IN_MILLISECONDS) {
-			updateItem(listPath, id, !isChecked);
+			updateItem(listPath, !isChecked, {
+				id,
+				dateLastPurchased,
+				totalPurchases,
+				dayInterval,
+				dateCreated,
+			});
 		}
 	}, []);
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,12 +3,19 @@ import { updateItem } from '../api';
 import { useEffect } from 'react';
 import { ONE_DAY_IN_MILLISECONDS } from '../utils/dates';
 
-export function ListItem({ name, listPath, id, isChecked, datePurchased }) {
+export function ListItem({
+	name,
+	listPath,
+	id,
+	isChecked,
+	datePurchased,
+	dayInterval,
+}) {
 	const handleOnChange = async (event) => {
 		let { checked } = event.target;
 		if (!checked) return;
 
-		await updateItem(listPath, id, checked);
+		await updateItem(listPath, id, checked, dayInterval);
 	};
 
 	useEffect(() => {
@@ -16,7 +23,7 @@ export function ListItem({ name, listPath, id, isChecked, datePurchased }) {
 		const datePurchasedInMillis = datePurchased?.toMillis();
 
 		if (isChecked && today - datePurchasedInMillis >= ONE_DAY_IN_MILLISECONDS) {
-			updateItem(listPath, id, !isChecked);
+			updateItem(listPath, id, !isChecked, dayInterval);
 		}
 	}, []);
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,27 +3,20 @@ import { updateItem } from '../api';
 import { useEffect } from 'react';
 import { ONE_DAY_IN_MILLISECONDS } from '../utils/dates';
 
-export function ListItem({
-	name,
-	listPath,
-	id,
-	isChecked,
-	datePurchased,
-	dayInterval,
-}) {
+export function ListItem({ name, listPath, id, isChecked, datePurchased }) {
 	const handleOnChange = async (event) => {
 		let { checked } = event.target;
 		if (!checked) return;
 
-		await updateItem(listPath, id, checked, dayInterval);
+		await updateItem(listPath, id, checked);
 	};
 
 	useEffect(() => {
 		const today = new Date().getTime();
-		const datePurchasedInMillis = datePurchased?.toMillis();
+		const datePurchasedInMillis = datePurchased;
 
 		if (isChecked && today - datePurchasedInMillis >= ONE_DAY_IN_MILLISECONDS) {
-			updateItem(listPath, id, !isChecked, dayInterval);
+			updateItem(listPath, id, !isChecked);
 		}
 	}, []);
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -13,7 +13,7 @@ export function ListItem({ name, listPath, id, isChecked, datePurchased }) {
 
 	useEffect(() => {
 		const today = new Date().getTime();
-		const datePurchasedInMillis = datePurchased;
+		const datePurchasedInMillis = datePurchased?.toMillis();
 
 		if (isChecked && today - datePurchasedInMillis >= ONE_DAY_IN_MILLISECONDS) {
 			updateItem(listPath, id, !isChecked);

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,11 @@ export const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+export function getDaysBetweenDates(startDate, endDate) {
+	const differenceInMillis = startDate.getTime() - endDate.getTime();
+	const daysSinceLastPurchase =
+		Math.round(differenceInMillis / ONE_DAY_IN_MILLISECONDS) === 0
+			? 1
+			: Math.round(differenceInMillis / ONE_DAY_IN_MILLISECONDS);
+	return daysSinceLastPurchase;
+}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -28,6 +28,7 @@ export function List({ data, listPath }) {
 						id={item.id}
 						isChecked={item.checked}
 						datePurchased={item.dateLastPurchased}
+						dayInterval={item.dayInterval}
 					/>
 				))}
 			</ul>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -27,7 +27,10 @@ export function List({ data, listPath }) {
 						listPath={listPath}
 						id={item.id}
 						isChecked={item.checked}
-						datePurchased={item.dateLastPurchased}
+						dateLastPurchased={item.dateLastPurchased}
+						totalPurchases={item.totalPurchases}
+						dayInterval={item.dayInterval}
+						dateCreated={item.dateCreated}
 					/>
 				))}
 			</ul>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -28,7 +28,6 @@ export function List({ data, listPath }) {
 						id={item.id}
 						isChecked={item.checked}
 						datePurchased={item.dateLastPurchased}
-						dayInterval={item.dayInterval}
 					/>
 				))}
 			</ul>


### PR DESCRIPTION

## Description

When a new purchase is recorded the next purchase date is automatically computed and the app learn how often the item is purchased.



<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue
Closes #11 

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them

<!-- Include AC from the Github issue -->

## Type of Changes

enhancement

## Updates

### Before
N/A

<!-- If UI feature, take provide screenshots -->

### After
N/A

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria
- Do a `git pull` and `git checkout mm-qg-predict-next-purchase`.
- Open the homepage by running `npm start`.
- Navigate to the `List` and check one of the items on the list.
- Check Firestore: the `dateLastPurchased`, `dateNextPurchased` and `dayInterval` should be updated according to how many days have elapsed since the item was last purchased.  

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
