### PR TITLE
Show error messages for adding empty or duplicate items

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -56,7 +56,7 @@ export function App() {
 					/>
 					<Route
 						path="/manage-list"
-						element={<ManageList listPath={listPath} user={user} />}
+						element={<ManageList listPath={listPath} user={user} data={data} />}
 					/>
 				</Route>
 			</Routes>

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -13,7 +13,7 @@ export function ListItem({ name, listPath, id, isChecked, datePurchased }) {
 
 	useEffect(() => {
 		const today = new Date().getTime();
-		const datePurchasedInMillis = datePurchased.toMillis();
+		const datePurchasedInMillis = datePurchased?.toMillis();
 
 		if (isChecked && today - datePurchasedInMillis >= ONE_DAY_IN_MILLISECONDS) {
 			updateItem(listPath, id, !isChecked);

--- a/src/components/ManageListForms/AddItemForm.jsx
+++ b/src/components/ManageListForms/AddItemForm.jsx
@@ -10,33 +10,23 @@ export default function AddItemForm({ listPath, data }) {
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();
-		// (for later) maybe simplified the replace and added trim() to remove spaces like this:
-		// .toLowerCase().replace(/[^\w]/g, '').trim();
-		// (for later) maybe make this a function and move it into utils
+
 		const formattedItemName = formData.itemName
 			.toLowerCase()
-			.replace(/[.,/#!$%^&*;:{}=\-_~()\s]/g, '')
-			.replace(/[^\w\s]/gi, '');
+			.replace(/[^a-z]/g, '');
 
-		console.log('formattedItemName', formattedItemName);
+		const match = data.find((item) => item.name === formattedItemName);
 
 		try {
-			// (for later) replace .filter with .some to make this true or false because it didnt work in some cases
-			const filteredList = data?.filter((item) => {
-				item.name === formData.itemName;
-			});
-
-			console.log('filteredList', filteredList);
-
-			if (filteredList.length === 0) {
-				// (done) replaced setFormData we had before with { ...formData, itemName: formattedItemName }
+			if (!match) {
 				await addItem(listPath, { ...formData, itemName: formattedItemName });
-				alert(`${formattedItemName} was added to the list successfully`);
+				toast.success(`${formattedItemName} added to the list successfully`);
 			} else {
 				toast.error(`${formattedItemName} is already on your list`);
+				return;
 			}
 		} catch (error) {
-			alert(`There was a problem adding ${formData.itemName} to the list`);
+			toast.error(`Failed to add ${formattedItemName} to the list`);
 		}
 	};
 

--- a/src/components/ManageListForms/AddItemForm.jsx
+++ b/src/components/ManageListForms/AddItemForm.jsx
@@ -20,13 +20,13 @@ export default function AddItemForm({ listPath, data }) {
 		try {
 			if (!match) {
 				await addItem(listPath, { ...formData, itemName: formattedItemName });
-				toast.success(`${formattedItemName} added to the list successfully`);
+				toast.success(`${formattedItemName} was added to your list`);
 			} else {
 				toast.error(`${formattedItemName} is already on your list`);
 				return;
 			}
 		} catch (error) {
-			toast.error(`Failed to add ${formattedItemName} to the list`);
+			toast.error(`Failed to add ${formattedItemName}`);
 		}
 	};
 

--- a/src/components/ManageListForms/AddItemForm.jsx
+++ b/src/components/ManageListForms/AddItemForm.jsx
@@ -1,15 +1,25 @@
 import { useState } from 'react';
 import { addItem } from '../../api/firebase';
 
-export default function AddItemForm({ listPath }) {
+export default function AddItemForm({ listPath, data }) {
 	const [formData, setFormData] = useState({
 		itemName: '',
 		daysUntilNextPurchase: '',
 	});
 
 	const handleSubmit = async (event) => {
+		event.preventDefault();
 		try {
-			event.preventDefault();
+			console.log(formData.itemName);
+			const submittedItem = formData.itemName
+				.toLowerCase()
+				.replace(/[.,/#!$%^&*;:{}=\-_`~()\s]/g, '')
+				.replace(/[^\w\s]/gi, '');
+			setFormData((prevData) => ({
+				...prevData,
+				itemName: submittedItem,
+			}));
+			console.log('after set form data,', submittedItem);
 			await addItem(listPath, formData);
 			alert(`${formData.itemName} was added to the list successfully`);
 		} catch (error) {

--- a/src/components/ManageListForms/AddItemForm.jsx
+++ b/src/components/ManageListForms/AddItemForm.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { addItem } from '../../api/firebase';
+import toast from 'react-hot-toast';
 
 export default function AddItemForm({ listPath, data }) {
 	const [formData, setFormData] = useState({
@@ -9,19 +10,31 @@ export default function AddItemForm({ listPath, data }) {
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();
+		// (for later) maybe simplified the replace and added trim() to remove spaces like this:
+		// .toLowerCase().replace(/[^\w]/g, '').trim();
+		// (for later) maybe make this a function and move it into utils
+		const formattedItemName = formData.itemName
+			.toLowerCase()
+			.replace(/[.,/#!$%^&*;:{}=\-_~()\s]/g, '')
+			.replace(/[^\w\s]/gi, '');
+
+		console.log('formattedItemName', formattedItemName);
+
 		try {
-			console.log(formData.itemName);
-			const submittedItem = formData.itemName
-				.toLowerCase()
-				.replace(/[.,/#!$%^&*;:{}=\-_`~()\s]/g, '')
-				.replace(/[^\w\s]/gi, '');
-			setFormData((prevData) => ({
-				...prevData,
-				itemName: submittedItem,
-			}));
-			console.log('after set form data,', submittedItem);
-			await addItem(listPath, formData);
-			alert(`${formData.itemName} was added to the list successfully`);
+			// (for later) replace .filter with .some to make this true or false because it didnt work in some cases
+			const filteredList = data?.filter((item) => {
+				item.name === formData.itemName;
+			});
+
+			console.log('filteredList', filteredList);
+
+			if (filteredList.length === 0) {
+				// (done) replaced setFormData we had before with { ...formData, itemName: formattedItemName }
+				await addItem(listPath, { ...formData, itemName: formattedItemName });
+				alert(`${formattedItemName} was added to the list successfully`);
+			} else {
+				toast.error(`${formattedItemName} is already on your list`);
+			}
 		} catch (error) {
 			alert(`There was a problem adding ${formData.itemName} to the list`);
 		}

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -1,10 +1,10 @@
 import AddItemForm from '../components/ManageListForms/AddItemForm';
 import ShareListForm from '../components/ManageListForms/ShareListForm';
 
-export function ManageList({ listPath, user }) {
+export function ManageList({ listPath, user, data }) {
 	return (
 		<div>
-			<AddItemForm listPath={listPath} />
+			<AddItemForm listPath={listPath} data={data} />
 			<ShareListForm listPath={listPath} user={user} />
 		</div>
 	);


### PR DESCRIPTION

## Description

This update prevents users from adding empty or duplicate items to their list. Users will receive appropriate error messages if they attempt to submit an empty item or an item that already exists in the list, including variations in casing and punctuation.

## Related Issue

Closes #10 

## Acceptance criteria
- [x] Show an error message if the user tries to submit an empty item
- [x] Show an error message if the user tries to submit a new item that is _identical_ to an existing name. For instance, if the list contains `apples` and the user adds `apples`.
- [x] Show an error message if the user tries to submit a new item that matches an existing name with punctuation and casing normalized. For instance, if the list contains `apples` and the user adds `aPples` or `apples,` or `a pples`.
- [x] The user’s original input is saved in the database.

## Type of Changes

Enhancement

## Updates

### Before

![Screen Shot 2024-09-13 at 13 06 34](https://github.com/user-attachments/assets/dfbfec52-723b-4680-938d-ed4164e96c9e)

### After

![Screen Shot 2024-09-13 at 12 41 00](https://github.com/user-attachments/assets/946b8587-f4d1-4727-a66d-f81da15789da)
![Screen Shot 2024-09-13 at 12 41 25](https://github.com/user-attachments/assets/7941d369-49cf-4591-8adf-af4ff0bb62f2)
![Screen Shot 2024-09-13 at 13 06 51](https://github.com/user-attachments/assets/92b0d9b7-57b0-4262-8240-87e02c0344e3)

## Testing Steps / QA Criteria

- Do a `git checkout jo-hm-check-item-input` and `git pull`.
- Open the homepage by running `npm start`.
- Navigate to `ManageList` and attempt to add an empty item, an error message will appear because the input field is required.
- Trying to add an item that already exists will result in an error message.
- Test adding an item with different casing or punctuation from an existing item, it should result in an error message.
- Navigate to `List` to verify that if the item was not already in the list, it is displayed in the list regardless of error conditions.

